### PR TITLE
clip:stop() passes table with 'stopped' key to 'ended' event

### DIFF
--- a/lua/medialib/service_bass.lua
+++ b/lua/medialib/service_bass.lua
@@ -172,14 +172,24 @@ function BASSMedia:getState()
 end
 
 function BASSMedia:play()
-	self:runCommand(function(chan) chan:Play() self:emit("playing") end)
+	self:runCommand(function(chan)
+		chan:Play()
+		self:emit("playing")
+	end)
 end
 function BASSMedia:pause()
-	self:runCommand(function(chan) chan:Pause() self:emit("paused") end)
+	self:runCommand(function(chan)
+		chan:Pause()
+		self:emit("paused")
+	end)
 end
 function BASSMedia:stop()
 	self._stopped = true
-	self:runCommand(function(chan) chan:Stop() self:emit("ended") self:emit("destroyed") end)
+	self:runCommand(function(chan)
+		chan:Stop()
+		self:emit("ended", {stopped = true})
+		self:emit("destroyed")
+	end)
 end
 
 function BASSMedia:isValid()

--- a/lua/medialib/service_html.lua
+++ b/lua/medialib/service_html.lua
@@ -232,6 +232,7 @@ function HTMLMedia:stop()
 	self.panel = nil
 
 	self.timeKeeper:pause()
+	self:emit("ended", {stopped = true})
 	self:emit("destroyed")
 end
 


### PR DESCRIPTION
`clip:stop()` now passes `{stopped = true}` to the `ended` event to signal it was stopped as suggest in [#49](https://github.com/wyozi/gmod-medialib/issues/49#issuecomment-155114971).

As far as I could tell, `HTMLMedia:stop()` never caused the `ended` event to be emitted so now that happens too.
